### PR TITLE
make Moose class immutable

### DIFF
--- a/moose.pl
+++ b/moose.pl
@@ -18,6 +18,8 @@ sub execute {
     return +{ name => $self->name, age => $self->age };
 }
 
+__PACKAGE__->meta->make_immutable;
+
 1;
 
 package main;


### PR DESCRIPTION
Moose constructors are quite slow by default, until you call `make_immutable`.